### PR TITLE
Add `AggregateInput` and `AggregateDataset`

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,19 +3,25 @@
 from pathlib import Path
 
 import pytest
+import torch
 from dicom_utils.dicom_factory import CompleteMammographyStudyFactory
 
 
 @pytest.fixture
-def dicom_iterator():
+def dicoms():
     fact = CompleteMammographyStudyFactory(Rows=2048, Columns=1536, seed=42)
-    return iter(fact())
+    return fact()
 
 
 @pytest.fixture
-def file_iterator(tmp_path, dicom_iterator):
+def dicom_iterator(dicoms):
+    return iter(dicoms)
+
+
+@pytest.fixture
+def file_iterator(tmp_path, dicoms):
     files = []
-    for i, dcm in enumerate(dicom_iterator):
+    for i, dcm in enumerate(dicoms):
         dest = Path(tmp_path, f"file_{i}.dcm")
         dcm.save_as(dest)
         files.append(dest)
@@ -29,3 +35,24 @@ def file_list(tmp_path, file_iterator):
         for path in file_iterator:
             f.write(f"{path}\n")
     return file_list
+
+
+@pytest.fixture
+def tensors():
+    torch.random.manual_seed(0)
+    return [torch.rand(1, 2048, 1536) for _ in range(12)]
+
+
+@pytest.fixture
+def tensor_input(tensors):
+    return iter(tensors)
+
+
+@pytest.fixture
+def tensor_files(tmp_path, tensors):
+    paths = []
+    for i, t in enumerate(tensors):
+        path = tmp_path / f"tensor_{i}.pt"
+        torch.save(t, path)
+        paths.append(path)
+    return iter(paths)

--- a/tests/test_datasets/test_chain.py
+++ b/tests/test_datasets/test_chain.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from typing import cast
+
+from torch.utils.data import DataLoader
+
+from torch_dicom.datasets import DicomExample, TensorExample, collate_fn
+from torch_dicom.datasets.chain import AggregateDataset, AggregateInput
+
+
+class TestAggregateInput:
+    def test_iter_dicoms(self, dicoms, file_iterator):
+        ds = AggregateInput(
+            dicom_paths=file_iterator,
+            dicoms=iter(dicoms),
+        )
+        contents = list(ds)
+        actual_dicoms = [cast(DicomExample, item)["dicom"] for item in contents]
+        expected_dicoms = dicoms * 2
+        assert len(actual_dicoms) == len(expected_dicoms)
+        assert all(
+            [
+                dicom.SOPInstanceUID == expected_dicom.SOPInstanceUID
+                for dicom, expected_dicom in zip(actual_dicoms, expected_dicoms)
+            ]
+        )
+
+    def test_iter_tensors(self, tensors, tensor_files):
+        ds = AggregateInput(
+            tensors=iter(tensors),
+            tensor_paths=iter(tensor_files),
+        )
+        contents = list(ds)
+        actual = [cast(TensorExample, item)["img"] for item in contents]
+        expected = tensors * 2
+        assert len(actual) == len(expected)
+        assert all([(act == exp).all() for act, exp in zip(actual, expected)])
+
+    def test_dataloader(self, dicoms, file_iterator):
+        ds = AggregateInput(
+            dicom_paths=file_iterator,
+            dicoms=iter(dicoms),
+        )
+        dl = DataLoader(ds, batch_size=1, collate_fn=collate_fn)
+        expected_dicoms = dicoms * 2
+        for i, batch in enumerate(dl):
+            assert batch["dicom"][0].SOPInstanceUID == expected_dicoms[i].SOPInstanceUID
+
+
+class TestAggregateDataset:
+    def test_iter_dicoms(self, dicoms, file_iterator):
+        ds = AggregateDataset(
+            dicom_paths=file_iterator,
+        )
+        contents = list(ds)
+        actual_dicoms = [cast(DicomExample, item)["dicom"] for item in contents]
+        expected_dicoms = dicoms
+        assert len(actual_dicoms) == len(expected_dicoms)
+        assert all(
+            [
+                dicom.SOPInstanceUID == expected_dicom.SOPInstanceUID
+                for dicom, expected_dicom in zip(actual_dicoms, expected_dicoms)
+            ]
+        )
+
+    def test_iter_tensors(self, tensors, tensor_files):
+        ds = AggregateDataset(
+            tensor_paths=iter(tensor_files),
+        )
+        contents = list(ds)
+        actual = [cast(TensorExample, item)["img"] for item in contents]
+        expected = tensors
+        assert len(actual) == len(expected)
+        assert all([(act == exp).all() for act, exp in zip(actual, expected)])
+
+    def test_dataloader(self, dicoms, file_iterator):
+        ds = AggregateDataset(
+            dicom_paths=file_iterator,
+        )
+        dl = DataLoader(ds, batch_size=1, collate_fn=collate_fn)
+        expected_dicoms = dicoms
+        for i, batch in enumerate(dl):
+            assert batch["dicom"][0].SOPInstanceUID == expected_dicoms[i].SOPInstanceUID

--- a/tests/test_datasets/test_dicom.py
+++ b/tests/test_datasets/test_dicom.py
@@ -14,13 +14,6 @@ from torch.utils.data import DataLoader
 from torch_dicom.datasets.dicom import DUMMY_PATH, DicomInput, DicomPathDataset, DicomPathInput, collate_fn
 
 
-@pytest.fixture
-def input_paths_iterator(file_list):
-    with open(file_list, "r") as f:
-        result = [line.strip() for line in f.readlines()]
-    return iter(result)
-
-
 class TestDicomInput:
     TEST_CLASS: ClassVar = DicomInput
 

--- a/tests/test_datasets/test_tensor.py
+++ b/tests/test_datasets/test_tensor.py
@@ -12,22 +12,6 @@ from torch_dicom.datasets.dicom import collate_fn
 from torch_dicom.datasets.tensor import TensorInput, TensorPathDataset, TensorPathInput
 
 
-@pytest.fixture
-def tensor_input():
-    torch.random.manual_seed(0)
-    return iter([torch.rand(1, 2048, 1536) for _ in range(12)])
-
-
-@pytest.fixture
-def tensor_files(tmp_path, tensor_input):
-    paths = []
-    for i, t in enumerate(tensor_input):
-        path = tmp_path / f"tensor_{i}.pt"
-        torch.save(t, path)
-        paths.append(path)
-    return iter(paths)
-
-
 class TestTensorInput:
     TEST_CLASS: ClassVar = TensorInput
 

--- a/torch_dicom/datasets/__init__.py
+++ b/torch_dicom/datasets/__init__.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from .dicom import DUMMY_PATH, DicomExample, DicomInput, DicomPathDataset, DicomPathInput
+from .chain import AggregateDataset, AggregateInput
+from .dicom import DUMMY_PATH, DicomExample, DicomInput, DicomPathDataset, DicomPathInput, collate_fn
 from .path import PathDataset, PathInput
-from .tensor import TensorInput, TensorPathDataset, TensorPathInput
+from .tensor import TensorExample, TensorInput, TensorPathDataset, TensorPathInput
 
 
 __all__ = [
@@ -17,4 +18,8 @@ __all__ = [
     "TensorInput",
     "TensorPathInput",
     "TensorPathDataset",
+    "AggregateInput",
+    "AggregateDataset",
+    "collate_fn",
+    "TensorExample",
 ]

--- a/torch_dicom/datasets/chain.py
+++ b/torch_dicom/datasets/chain.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+from pathlib import Path
+from typing import Iterable, Iterator, Union
+
+from dicom_utils.dicom import Dicom
+from torch import Tensor
+from torch.utils.data import ChainDataset, ConcatDataset
+
+from .dicom import DicomExample, DicomInput, DicomPathDataset, DicomPathInput
+from .tensor import TensorExample, TensorInput, TensorPathDataset, TensorPathInput
+
+
+class AggregateInput(ChainDataset):
+    r"""Chain dataset that aggregates multiple input sources using the respective dataset types.
+
+    Args:
+        dicom_paths: Iterable of paths to DICOM files.
+        dicoms: Iterable of DICOM objects.
+        tensor_paths: Iterable of paths to tensor files.
+        tensors: Iterable of tensors.
+    """
+
+    def __init__(
+        self,
+        dicom_paths: Iterable[Path] = [],
+        dicoms: Iterable[Dicom] = [],
+        tensor_paths: Iterable[Path] = [],
+        tensors: Iterable[Tensor] = [],
+        **kwargs,
+    ):
+        dicom_file_ds = DicomPathInput(dicom_paths, **kwargs)
+        dicom_object_ds = DicomInput(dicoms, **kwargs)
+        tensor_file_ds = TensorPathInput(tensor_paths, **kwargs)
+        tensor_object_ds = TensorInput(tensors, **kwargs)
+        super().__init__(
+            [
+                dicom_file_ds,
+                dicom_object_ds,
+                tensor_file_ds,
+                tensor_object_ds,
+            ]
+        )
+
+    def __iter__(self) -> Iterator[Union[DicomExample, TensorExample]]:
+        return super().__iter__()
+
+
+class AggregateDataset(ConcatDataset):
+    r"""Concat dataset that aggregates multiple input sources using the respective dataset types.
+    Use this for training or when a dataset size or getitem support is needed.
+
+    Args:
+        dicom_paths: Iterable of paths to DICOM files.
+        tensor_paths: Iterable of paths to tensor files.
+    """
+
+    def __init__(
+        self,
+        dicom_paths: Iterable[Path] = [],
+        tensor_paths: Iterable[Path] = [],
+        **kwargs,
+    ):
+        dicom_file_ds = DicomPathDataset(iter(dicom_paths), **kwargs)
+        tensor_file_ds = TensorPathDataset(iter(tensor_paths), **kwargs)
+        super().__init__(
+            [
+                dicom_file_ds,
+                tensor_file_ds,
+            ]
+        )
+
+    def __getitem__(self, idx: int) -> Union[DicomExample, TensorExample]:
+        return super().__getitem__(idx)
+
+    def __iter__(self) -> Iterator[Union[DicomExample, TensorExample]]:
+        for i in range(len(self)):
+            yield self[i]


### PR DESCRIPTION
These classes provide support for the following existing functionality:

https://github.com/medcognetics/tissue-mask/blob/ef8b3176c06c6b81001ecebbf6ed31a88f45ffc3/tissue_mask/tasks/predict.py#L206-L210

Also includes some changes / regorganization of test fixtures. Some test fixtures based on iterators would be exhausted when used in conjunction with other fixtures.