### PR TITLE
Skip preprocessing errors by default

### DIFF
--- a/torch_dicom/preprocessing/pipeline.py
+++ b/torch_dicom/preprocessing/pipeline.py
@@ -160,6 +160,7 @@ class PreprocessingPipeline:
             normalize=False,
             voi_lut=False,
             volume_handler=self.volume_handler,
+            skip_errors=True,
         )
         return DataLoader(
             ds,


### PR DESCRIPTION
Needed to prevent corrupt images from triggering a failure of the entire preprocessing run