### PR TITLE
Fix VOILUT and inversion application

### DIFF
--- a/pdm.lock
+++ b/pdm.lock
@@ -102,10 +102,10 @@ dependencies = [
 
 [[package]]
 name = "dicom-utils"
-version = "0.1.dev93+gacebf09"
+version = "0.1.dev94+g60b7717"
 requires_python = ">=3.8"
 git = "https://github.com/medcognetics/dicom-utils.git"
-revision = "acebf09a2c6219dd05264b812c72f771d05a269c"
+revision = "60b771715193f86b889b8b90eda7618dafca9707"
 summary = ""
 dependencies = [
     "Pillow",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,6 +15,11 @@ def dicoms():
     fact = CompleteMammographyStudyFactory(Rows=2048, Columns=1536, seed=42, WindowCenter=5, WindowWidth=4)
     dicoms = fact()
 
+    # Ensure we have a mix of inversions
+    dicoms[0].PhotometricInterpretation = "MONOCHROME1"
+    dicoms[1].PhotometricInterpretation = "MONOCHROME2"
+
+    # Ensure we have a mix of TSUIDs
     tsuids = (ImplicitVRLittleEndian, ExplicitVRLittleEndian, RLELossless)
     for dcm, tsuid in zip(dicoms[: len(tsuids)], tsuids):
         set_pixels(dcm, dcm.pixel_array, tsuid)

--- a/torch_dicom/preprocessing/pipeline.py
+++ b/torch_dicom/preprocessing/pipeline.py
@@ -9,7 +9,7 @@ from typing import Any, Callable, Dict, Iterable, Iterator, Sequence, Set, cast
 
 import numpy as np
 import torch
-from dicom_utils.dicom import ALGORITHM_PRESENTATION_TYPE, Dicom, set_pixels
+from dicom_utils.dicom import Dicom, set_pixels
 from dicom_utils.volume import KeepVolume, VolumeHandler
 from pydicom.dataset import FileDataset
 from pydicom.uid import ExplicitVRLittleEndian, ImplicitVRLittleEndian
@@ -109,7 +109,6 @@ class PreprocessingPipeline:
                 assert isinstance(img, Tensor)
                 dicom = update_dicom(dicom, img)
                 dicom["PixelData"].VR = "OB"
-                dicom.PresentationIntentType = ALGORITHM_PRESENTATION_TYPE
 
                 # Propagate to dict and yield
                 example["dicom"] = dicom
@@ -159,6 +158,7 @@ class PreprocessingPipeline:
             dicoms=self.dicoms,
             normalize=False,
             voi_lut=False,
+            inversion=False,
             volume_handler=self.volume_handler,
             skip_errors=True,
         )


### PR DESCRIPTION
~Add test for #28.~ Resolves #28. Inversion and VOILUT application are disabled at preprocessing time. They will be applied when reading the preprocessed image.