### PR TITLE
Add wrappers for injecting metadata

### DIFF
--- a/tests/test_datasets/test_metadata.py
+++ b/tests/test_datasets/test_metadata.py
@@ -1,0 +1,97 @@
+from pathlib import Path
+from typing import Any, Dict
+
+import pandas as pd
+import pytest
+from torch.utils.data import Dataset
+
+from torch_dicom.datasets.metadata import MetadataDatasetWrapper, MetadataInputWrapper
+
+
+class DummyMetadataInputWrapper(MetadataInputWrapper):
+    def load_metadata(self, metadata: Path) -> Any:
+        return pd.read_csv(metadata)
+
+    def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        return {"dummy": "metadata"}
+
+
+class DummyMetadataDatasetWrapper(MetadataDatasetWrapper):
+    def load_metadata(self, metadata: Path) -> Any:
+        return pd.read_csv(metadata)
+
+    def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        return {"dummy": "metadata"}
+
+
+class DummyDataset(Dataset):
+    def __init__(self):
+        self.data = [{"dummy": "data"} for _ in range(10)]
+
+    def __len__(self):
+        return len(self.data)
+
+    def __getitem__(self, idx):
+        return self.data[idx]
+
+
+@pytest.fixture(scope="module")
+def dataset() -> Dataset:
+    return DummyDataset()
+
+
+class TestMetadataInputWrapper:
+    @pytest.fixture
+    def metadata(self, tmp_path: Path) -> Path:
+        metadata_file = tmp_path / "metadata.csv"
+        metadata_file.write_text("dummy,metadata\n1,test")
+        return metadata_file
+
+    def test_init(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataInputWrapper(dataset, metadata)
+        assert wrapper.dataset == dataset
+        assert isinstance(wrapper.metadata, pd.DataFrame)
+
+    def test_load_metadata(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataInputWrapper(dataset, metadata)
+        assert isinstance(wrapper.load_metadata(metadata), pd.DataFrame)
+
+    def test_get_metadata(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataInputWrapper(dataset, metadata)
+        assert wrapper.get_metadata({}) == {"dummy": "metadata"}
+
+    def test_iter(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataInputWrapper(dataset, metadata)
+        for item in wrapper:
+            assert isinstance(item, dict)
+            assert "dummy" in item
+
+
+class TestMetadataDatasetWrapper:
+    @pytest.fixture
+    def metadata(self, tmp_path: Path) -> Path:
+        metadata_file = tmp_path / "metadata.csv"
+        metadata_file.write_text("dummy,metadata\n1,test")
+        return metadata_file
+
+    def test_init(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataDatasetWrapper(dataset, metadata)
+        assert wrapper.dataset == dataset
+        assert isinstance(wrapper.metadata, pd.DataFrame)
+
+    def test_load_metadata(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataDatasetWrapper(dataset, metadata)
+        assert isinstance(wrapper.load_metadata(metadata), pd.DataFrame)
+
+    def test_get_metadata(self, dataset: Dataset, metadata: Path):
+        wrapper = DummyMetadataDatasetWrapper(dataset, metadata)
+        assert wrapper.get_metadata({}) == {"dummy": "metadata"}
+
+    def test_len(self, dataset, metadata: Path):
+        wrapper = DummyMetadataDatasetWrapper(dataset, metadata)
+        assert len(wrapper) == len(dataset)
+
+    def test_getitem(self, dataset, metadata: Path):
+        wrapper = DummyMetadataDatasetWrapper(dataset, metadata)
+        for i in range(len(dataset)):
+            assert wrapper[i] == dataset[i]

--- a/tests/test_datasets/test_metadata.py
+++ b/tests/test_datasets/test_metadata.py
@@ -193,22 +193,21 @@ class TestBoundingBoxMetadata:
         dest = tmp_path_factory.mktemp("boxes")
         np.random.seed(0)
         boxes = []
-        for i, dicom in enumerate(dicoms):
-            if i % 2 == 0:
-                rows, cols = dicom.Rows, dicom.Columns
-                x1 = np.random.randint(0, cols)
-                y1 = np.random.randint(0, rows)
-                x2 = np.random.randint(x1, cols)
-                y2 = np.random.randint(y1, rows)
-                metadata = {
-                    "SOPInstanceUID": dicom.SOPInstanceUID,
-                    "x1": x1,
-                    "y1": y1,
-                    "x2": x2,
-                    "y2": y2,
-                    "extra": "metadata",
-                }
-                boxes.append(metadata)
+        for dicom in dicoms[::2]:
+            rows, cols = dicom.Rows, dicom.Columns
+            x1 = np.random.randint(0, cols)
+            y1 = np.random.randint(0, rows)
+            x2 = np.random.randint(x1, cols)
+            y2 = np.random.randint(y1, rows)
+            metadata = {
+                "SOPInstanceUID": dicom.SOPInstanceUID,
+                "x1": x1,
+                "y1": y1,
+                "x2": x2,
+                "y2": y2,
+                "extra": "metadata",
+            }
+            boxes.append(metadata)
 
         # Write boxes to a CSV file
         path = dest / "boxes.csv"
@@ -264,14 +263,13 @@ class TestDataFrameMetadata:
     def metadata(self, dicoms, tmp_path_factory) -> Path:
         dest = tmp_path_factory.mktemp("metadata")
         rows = []
-        for i, dicom in enumerate(dicoms):
-            if i % 2 == 0:
-                metadata = {
-                    "SOPInstanceUID": dicom.SOPInstanceUID,
-                    "rows": dicom.Rows,
-                    "columns": dicom.Columns,
-                }
-                rows.append(metadata)
+        for dicom in dicoms[::2]:
+            metadata = {
+                "SOPInstanceUID": dicom.SOPInstanceUID,
+                "rows": dicom.Rows,
+                "columns": dicom.Columns,
+            }
+            rows.append(metadata)
 
         # Write boxes to a CSV file
         path = dest / "metadata.csv"

--- a/tests/test_datasets/test_metadata.py
+++ b/tests/test_datasets/test_metadata.py
@@ -16,7 +16,7 @@ from torch_dicom.datasets.metadata import (
     PreprocessingConfigMetadata,
 )
 from torch_dicom.preprocessing import MinMaxCrop, Resize
-from torch_dicom.preprocessing.pipeline import PreprocessingPipeline
+from torch_dicom.preprocessing.pipeline import OutputFormat, PreprocessingPipeline
 
 
 class DummyMetadataInputWrapper(MetadataInputWrapper):
@@ -126,7 +126,7 @@ class TestPreprocessingConfigMetadata:
     @pytest.fixture(scope="class")
     def preprocessed_data(self, tmp_path_factory, dicoms):
         dest = tmp_path_factory.mktemp("data")
-        pipeline = PreprocessingPipeline(dicoms=dicoms)
+        pipeline = PreprocessingPipeline(dicoms=dicoms, output_format=OutputFormat.DICOM)
         out_files = pipeline(dest)
         assert out_files
         return dest
@@ -176,7 +176,7 @@ class TestBoundingBoxMetadata:
             MinMaxCrop(),
             Resize((512, 384)),
         ]
-        pipeline = PreprocessingPipeline(dicoms=dicoms, transforms=transforms)
+        pipeline = PreprocessingPipeline(dicoms=dicoms, transforms=transforms, output_format=OutputFormat.DICOM)
         out_files = pipeline(dest)
         assert out_files
         return dest
@@ -247,7 +247,7 @@ class TestDataFrameMetadata:
     @pytest.fixture(scope="class")
     def preprocessed_data(self, tmp_path_factory, dicoms):
         dest = tmp_path_factory.mktemp("data")
-        pipeline = PreprocessingPipeline(dicoms=dicoms)
+        pipeline = PreprocessingPipeline(dicoms=dicoms, output_format=OutputFormat.DICOM)
         out_files = pipeline(dest)
         assert out_files
         return dest

--- a/torch_dicom/datasets/__init__.py
+++ b/torch_dicom/datasets/__init__.py
@@ -3,6 +3,7 @@
 
 from .chain import AggregateDataset, AggregateInput
 from .dicom import DUMMY_PATH, DicomExample, DicomInput, DicomPathDataset, DicomPathInput, collate_fn, uncollate
+from .metadata import MetadataDatasetWrapper, MetadataInputWrapper
 from .path import PathDataset, PathInput
 from .tensor import TensorExample, TensorInput, TensorPathDataset, TensorPathInput
 
@@ -23,4 +24,6 @@ __all__ = [
     "collate_fn",
     "TensorExample",
     "uncollate",
+    "MetadataInputWrapper",
+    "MetadataDatasetWrapper",
 ]

--- a/torch_dicom/datasets/__init__.py
+++ b/torch_dicom/datasets/__init__.py
@@ -3,7 +3,7 @@
 
 from .chain import AggregateDataset, AggregateInput
 from .dicom import DUMMY_PATH, DicomExample, DicomInput, DicomPathDataset, DicomPathInput, collate_fn, uncollate
-from .metadata import MetadataDatasetWrapper, MetadataInputWrapper, PreprocessingConfigMetadata
+from .metadata import BoundingBoxMetadata, MetadataDatasetWrapper, MetadataInputWrapper, PreprocessingConfigMetadata
 from .path import PathDataset, PathInput
 from .tensor import TensorExample, TensorInput, TensorPathDataset, TensorPathInput
 
@@ -27,4 +27,5 @@ __all__ = [
     "MetadataInputWrapper",
     "MetadataDatasetWrapper",
     "PreprocessingConfigMetadata",
+    "BoundingBoxMetadata",
 ]

--- a/torch_dicom/datasets/__init__.py
+++ b/torch_dicom/datasets/__init__.py
@@ -3,7 +3,7 @@
 
 from .chain import AggregateDataset, AggregateInput
 from .dicom import DUMMY_PATH, DicomExample, DicomInput, DicomPathDataset, DicomPathInput, collate_fn, uncollate
-from .metadata import MetadataDatasetWrapper, MetadataInputWrapper
+from .metadata import MetadataDatasetWrapper, MetadataInputWrapper, PreprocessingConfigMetadata
 from .path import PathDataset, PathInput
 from .tensor import TensorExample, TensorInput, TensorPathDataset, TensorPathInput
 
@@ -26,4 +26,5 @@ __all__ = [
     "uncollate",
     "MetadataInputWrapper",
     "MetadataDatasetWrapper",
+    "PreprocessingConfigMetadata",
 ]

--- a/torch_dicom/datasets/__init__.py
+++ b/torch_dicom/datasets/__init__.py
@@ -3,7 +3,13 @@
 
 from .chain import AggregateDataset, AggregateInput
 from .dicom import DUMMY_PATH, DicomExample, DicomInput, DicomPathDataset, DicomPathInput, collate_fn, uncollate
-from .metadata import BoundingBoxMetadata, MetadataDatasetWrapper, MetadataInputWrapper, PreprocessingConfigMetadata
+from .metadata import (
+    BoundingBoxMetadata,
+    DataFrameMetadata,
+    MetadataDatasetWrapper,
+    MetadataInputWrapper,
+    PreprocessingConfigMetadata,
+)
 from .path import PathDataset, PathInput
 from .tensor import TensorExample, TensorInput, TensorPathDataset, TensorPathInput
 
@@ -28,4 +34,5 @@ __all__ = [
     "MetadataDatasetWrapper",
     "PreprocessingConfigMetadata",
     "BoundingBoxMetadata",
+    "DataFrameMetadata",
 ]

--- a/torch_dicom/datasets/metadata.py
+++ b/torch_dicom/datasets/metadata.py
@@ -1,4 +1,6 @@
+import json
 from abc import ABC, abstractclassmethod, abstractmethod
+from functools import cached_property
 from pathlib import Path
 from typing import Any, Dict, Iterator, Sized, Union, cast
 
@@ -17,12 +19,14 @@ class MetadataInputWrapper(IterableDataset, ABC):
         self.dataset = dataset
         if not metadata.is_file():
             raise FileNotFoundError(f"Metadata file {metadata} does not exist.")  # pragma: no cover
-        self.metadata = self.load_metadata(Path(metadata))
+        self.metadata_path = Path(metadata)
+        # Trigger loading of metadata
+        self.metadata
 
     @abstractclassmethod
     def load_metadata(cls, metadata: Path) -> Any:
         r"""Loads metadata from a file."""
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
     def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
@@ -31,7 +35,11 @@ class MetadataInputWrapper(IterableDataset, ABC):
         Returns:
             Dictionary of metadata to be added to the example.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
+
+    @cached_property
+    def metadata(self) -> Any:
+        return self.load_metadata(self.metadata_path)
 
     def __iter__(self) -> Iterator[Dict[str, Any]]:
         for example in self.dataset:
@@ -42,6 +50,9 @@ class MetadataInputWrapper(IterableDataset, ABC):
             metadata = self.get_metadata(example)
             example.update(metadata)
             yield example
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(dataset={self.dataset}, metadata={self.metadata_path})"
 
 
 class MetadataDatasetWrapper(Dataset, ABC):
@@ -56,12 +67,14 @@ class MetadataDatasetWrapper(Dataset, ABC):
         self.dataset = dataset
         if not metadata.is_file():
             raise FileNotFoundError(f"Metadata file {metadata} does not exist.")  # pragma: no cover
-        self.metadata = self.load_metadata(Path(metadata))
+        self.metadata_path = Path(metadata)
+        # Trigger loading of metadata
+        self.metadata
 
     @abstractclassmethod
     def load_metadata(cls, metadata: Path) -> Any:
         r"""Loads metadata from a file."""
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
 
     @abstractmethod
     def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
@@ -70,7 +83,11 @@ class MetadataDatasetWrapper(Dataset, ABC):
         Returns:
             Dictionary of metadata to be added to the example.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover
+
+    @cached_property
+    def metadata(self) -> Any:
+        return self.load_metadata(self.metadata_path)
 
     def __len__(self) -> int:
         return len(cast(Sized, self.dataset))
@@ -78,7 +95,9 @@ class MetadataDatasetWrapper(Dataset, ABC):
     def __getitem__(self, idx: int) -> Dict[str, Any]:
         example = self.dataset[idx]
         if not isinstance(example, dict):
-            raise TypeError(f"{self.__class__.__name__} expects examples to be of type dict, got {type(example)}")
+            raise TypeError(
+                f"{self.__class__.__name__} expects examples to be of type dict, got {type(example)}"
+            )  # pragma: no cover
         metadata = self.get_metadata(example)
         example.update(metadata)
         return example
@@ -86,3 +105,59 @@ class MetadataDatasetWrapper(Dataset, ABC):
     def __iter__(self) -> Iterator[Dict[str, Any]]:
         for i in range(len(self)):
             yield self[i]
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(dataset={self.dataset}, metadata={self.metadata_path})"
+
+
+class PreprocessingConfigMetadata(MetadataDatasetWrapper):
+    r"""Adds preprocessing configuration metadata to a dataset that was preprocessed
+    using this library. It is assumed that the preprocessed data contains "images"
+    and "metadata" subdirectories. The respective metadata JSON file is loaded
+    by replacing the "images" directory with "metadata" and changing the file
+    extension to ".json".
+
+    The loaded metadata is added to the example under the key "preprocessing".
+
+    Args:
+        dataset: Dataset to wrap.
+        metadata: Path to directory of metadata JSON files.
+    """
+
+    def __init__(self, dataset: Dataset):
+        self.dataset = dataset
+
+    @classmethod
+    def load_metadata(cls, metadata: Path) -> Any:
+        r"""Loads metadata from a file."""
+        if not metadata.is_file():
+            raise FileNotFoundError(metadata)  # pragma: no cover
+        with open(metadata, "r") as f:
+            return json.load(f)
+
+    def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        r"""Gets preprocessing metadata for a given example.
+
+        Returns:
+            Dictionary of metadata to be added to the example.
+        """
+        if not isinstance(example, dict):
+            raise TypeError(
+                f"{self.__class__.__name__} expects examples to be of type dict, got {type(example)}"
+            )  # pragma: no cover
+
+        path = (
+            example["path"]
+            if "path" in example and example["path"] is not None
+            else example["record"].path
+            if "record" in example
+            else None
+        )
+        if path is None:
+            raise KeyError(f"Unable to find path in example {example}")  # pragma: no cover
+
+        path = Path(str(path).replace("images", "metadata")).with_suffix(".json")
+        return {"preprocessing": self.load_metadata(path)}
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(dataset={self.dataset})"

--- a/torch_dicom/datasets/metadata.py
+++ b/torch_dicom/datasets/metadata.py
@@ -1,0 +1,88 @@
+from abc import ABC, abstractclassmethod, abstractmethod
+from pathlib import Path
+from typing import Any, Dict, Iterator, Sized, Union, cast
+
+from torch.utils.data import Dataset, IterableDataset
+
+
+class MetadataInputWrapper(IterableDataset, ABC):
+    r"""Wraps an existing input that returns a dictionary of items and adds metadata from a file.
+
+    Args:
+        dataset: Iterable dataset to wrap.
+        metadata: Path to a file with metadata.
+    """
+
+    def __init__(self, dataset: Union[Dataset, IterableDataset], metadata: Path):
+        self.dataset = dataset
+        if not metadata.is_file():
+            raise FileNotFoundError(f"Metadata file {metadata} does not exist.")  # pragma: no cover
+        self.metadata = self.load_metadata(Path(metadata))
+
+    @abstractclassmethod
+    def load_metadata(cls, metadata: Path) -> Any:
+        r"""Loads metadata from a file."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        r"""Gets metadata for a given example.
+
+        Returns:
+            Dictionary of metadata to be added to the example.
+        """
+        raise NotImplementedError
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        for example in self.dataset:
+            if not isinstance(example, dict):
+                raise TypeError(
+                    f"{self.__class__.__name__} expects examples to be of type dict, got {type(example)}"
+                )  # pragma: no cover
+            metadata = self.get_metadata(example)
+            example.update(metadata)
+            yield example
+
+
+class MetadataDatasetWrapper(Dataset, ABC):
+    r"""Wraps an existing dataset that returns a dictionary of items and adds metadata from a file.
+
+    Args:
+        dataset: Dataset to wrap.
+        metadata: Path to a file with metadata.
+    """
+
+    def __init__(self, dataset: Dataset, metadata: Path):
+        self.dataset = dataset
+        if not metadata.is_file():
+            raise FileNotFoundError(f"Metadata file {metadata} does not exist.")  # pragma: no cover
+        self.metadata = self.load_metadata(Path(metadata))
+
+    @abstractclassmethod
+    def load_metadata(cls, metadata: Path) -> Any:
+        r"""Loads metadata from a file."""
+        raise NotImplementedError
+
+    @abstractmethod
+    def get_metadata(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        r"""Gets metadata for a given example.
+
+        Returns:
+            Dictionary of metadata to be added to the example.
+        """
+        raise NotImplementedError
+
+    def __len__(self) -> int:
+        return len(cast(Sized, self.dataset))
+
+    def __getitem__(self, idx: int) -> Dict[str, Any]:
+        example = self.dataset[idx]
+        if not isinstance(example, dict):
+            raise TypeError(f"{self.__class__.__name__} expects examples to be of type dict, got {type(example)}")
+        metadata = self.get_metadata(example)
+        example.update(metadata)
+        return example
+
+    def __iter__(self) -> Iterator[Dict[str, Any]]:
+        for i in range(len(self)):
+            yield self[i]

--- a/torch_dicom/preprocessing/crop.py
+++ b/torch_dicom/preprocessing/crop.py
@@ -3,13 +3,18 @@
 
 import warnings
 from dataclasses import dataclass
-from typing import Any, Dict, Optional, Tuple, TypeVar, Union, cast, overload
+from typing import TYPE_CHECKING, Any, Dict, Optional, Tuple, TypeVar, Union, cast, overload
 
 import torch
 from einops import reduce, repeat
 from torch import Tensor
 
-from ..datasets import DicomExample, TensorExample
+
+if TYPE_CHECKING:
+    from ..datasets import DicomExample, TensorExample
+else:
+    DicomExample = Any
+    TensorExample = Any
 
 
 E = TypeVar("E", bound=Union[DicomExample, TensorExample, Dict[str, Any]])


### PR DESCRIPTION
To maximize compatibility with multiple dataset types, this PR implements metadata injection as a wrapper dataset around existing datasets that return dictionaries. Multiple metadata injection wrappers can be composed to incorporate multiple metadata sources. Wrappers are provided to support injecting trace level and image level metadata from CSV files.