### PR TITLE
Fix transform application in wrappers

### DIFF
--- a/tests/test_datasets/test_metadata.py
+++ b/tests/test_datasets/test_metadata.py
@@ -5,6 +5,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from torch.utils.data import Dataset
+from torchvision.transforms.v2 import RandomHorizontalFlip
 from torchvision.tv_tensors import BoundingBoxes, BoundingBoxFormat
 
 from torch_dicom.datasets import DicomPathDataset
@@ -241,6 +242,16 @@ class TestBoundingBoxMetadata:
         example = wrapper[1]
         assert isinstance(example, dict)
         assert example["bounding_boxes"] == {}
+
+    def test_transform(self, dataset: Dataset, box_data):
+        wrapper = BoundingBoxMetadata(dataset, box_data)
+        example1 = wrapper[0]
+        wrapper.transform = RandomHorizontalFlip(1.0)
+        example2 = wrapper[0]
+
+        boxes1 = example1["bounding_boxes"]["boxes"]
+        boxes2 = example2["bounding_boxes"]["boxes"]
+        assert not (boxes1 == boxes2).all()
 
 
 class TestDataFrameMetadata:

--- a/torch_dicom/datasets/helpers.py
+++ b/torch_dicom/datasets/helpers.py
@@ -1,4 +1,11 @@
+from typing import Any, Callable, Dict, Optional, Protocol, TypeVar, runtime_checkable
+
 from torch import Tensor
+
+
+E = TypeVar("E", bound=Dict[str, Any])
+
+Transform = Callable[[E], E]
 
 
 def normalize_pixels(pixels: Tensor, eps: float = 1e-6) -> Tensor:
@@ -16,3 +23,54 @@ def normalize_pixels(pixels: Tensor, eps: float = 1e-6) -> Tensor:
     delta = (pmax - pmin).clip(min=eps)
     pixels = (pixels.float() - pmin).div_(delta)
     return pixels
+
+
+@runtime_checkable
+class SupportsTransform(Protocol):
+    """
+    Protocol for classes that support applying a transform to an example.
+    """
+
+    transform: Optional[Transform]
+
+    def on_before_transform(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Method to be called before the transform is applied.
+        By default, it returns the example unchanged.
+
+        Args:
+            example: The example to be transformed.
+
+        Returns:
+            The example after any preprocessing.
+        """
+        return example
+
+    def on_after_transform(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Method to be called after the transform is applied.
+        By default, it returns the example unchanged.
+
+        Args:
+            example: The example that was transformed.
+
+        Returns:
+            The example after any postprocessing.
+        """
+        return example
+
+    def apply_transform(self, example: Dict[str, Any]) -> Dict[str, Any]:
+        """
+        Applies the transform to the example, with optional preprocessing and postprocessing.
+
+        Args:
+            example: The example to be transformed.
+
+        Returns:
+            The example after the transform and any preprocessing and postprocessing have been applied.
+        """
+        if self.transform is not None:
+            example = self.on_before_transform(example)
+            example = self.transform(example)
+            example = self.on_after_transform(example)
+        return example

--- a/torch_dicom/datasets/metadata.py
+++ b/torch_dicom/datasets/metadata.py
@@ -11,6 +11,7 @@ from torchvision.tv_tensors import BoundingBoxes, BoundingBoxFormat
 
 from ..preprocessing.crop import MinMaxCrop
 from ..preprocessing.resize import Resize
+from .helpers import SupportsTransform, Transform
 
 
 def get_sopuid_key_from_example(example: Dict[str, Any]) -> Optional[Any]:
@@ -38,13 +39,29 @@ def get_sopuid_key_from_example(example: Dict[str, Any]) -> Optional[Any]:
     return key
 
 
-class MetadataInputWrapper(IterableDataset, ABC):
+def _disable_wrapped_transform(wrapper: Union["MetadataDatasetWrapper", "MetadataInputWrapper"]) -> None:
+    r"""Disables the transform in the wrapped dataset and attaches the transform to the wrapper."""
+    if isinstance(wrapper.dataset, SupportsTransform):
+        wrapper.transform = wrapper.dataset.transform
+        wrapper.dataset.transform = None
+    else:
+        wrapper.transform = None
+
+
+def _assert_wrapped_transform_disabled(wrapper: Union["MetadataDatasetWrapper", "MetadataInputWrapper"]) -> None:
+    assert (
+        not isinstance(wrapper.dataset, SupportsTransform) or wrapper.dataset.transform is None
+    ), "Transform in wrapped dataset must be disabled"
+
+
+class MetadataInputWrapper(IterableDataset, ABC, SupportsTransform):
     r"""Wraps an existing input that returns a dictionary of items and adds metadata from a file.
 
     Args:
         dataset: Iterable dataset to wrap.
         metadata: Path to a file with metadata.
     """
+    transform: Optional[Transform]
 
     def __init__(self, dataset: Union[Dataset, IterableDataset], metadata: Path):
         self.dataset = dataset
@@ -53,6 +70,7 @@ class MetadataInputWrapper(IterableDataset, ABC):
         self.metadata_path = Path(metadata)
         # Trigger loading of metadata
         self.metadata
+        _disable_wrapped_transform(self)
 
     @abstractclassmethod
     def load_metadata(cls, metadata: Path) -> Any:
@@ -73,6 +91,7 @@ class MetadataInputWrapper(IterableDataset, ABC):
         return self.load_metadata(self.metadata_path)
 
     def __iter__(self) -> Iterator[Dict[str, Any]]:
+        _assert_wrapped_transform_disabled(self)
         for example in self.dataset:
             if not isinstance(example, dict):
                 raise TypeError(
@@ -80,19 +99,25 @@ class MetadataInputWrapper(IterableDataset, ABC):
                 )  # pragma: no cover
             metadata = self.get_metadata(example)
             example.update(metadata)
+
+            # Apply transform
+            if self.transform is not None:
+                example = self.apply_transform(example)
+
             yield example
 
     def __repr__(self) -> str:
         return f"{self.__class__.__name__}(dataset={self.dataset}, metadata={self.metadata_path})"
 
 
-class MetadataDatasetWrapper(Dataset, ABC):
+class MetadataDatasetWrapper(Dataset, ABC, SupportsTransform):
     r"""Wraps an existing dataset that returns a dictionary of items and adds metadata from a file.
 
     Args:
         dataset: Dataset to wrap.
         metadata: Path to a file with metadata.
     """
+    transform: Optional[Transform]
 
     def __init__(self, dataset: Dataset, metadata: Path):
         self.dataset = dataset
@@ -101,6 +126,7 @@ class MetadataDatasetWrapper(Dataset, ABC):
         self.metadata_path = Path(metadata)
         # Trigger loading of metadata
         self.metadata
+        _disable_wrapped_transform(self)
 
     @abstractclassmethod
     def load_metadata(cls, metadata: Path) -> Any:
@@ -124,6 +150,7 @@ class MetadataDatasetWrapper(Dataset, ABC):
         return len(cast(Sized, self.dataset))
 
     def __getitem__(self, idx: int) -> Dict[str, Any]:
+        _assert_wrapped_transform_disabled(self)
         example = self.dataset[idx]
         if not isinstance(example, dict):
             raise TypeError(
@@ -131,6 +158,11 @@ class MetadataDatasetWrapper(Dataset, ABC):
             )  # pragma: no cover
         metadata = self.get_metadata(example)
         example.update(metadata)
+
+        # Apply transform
+        if self.transform is not None:
+            example = self.apply_transform(example)
+
         return example
 
     def __iter__(self) -> Iterator[Dict[str, Any]]:
@@ -157,6 +189,7 @@ class PreprocessingConfigMetadata(MetadataDatasetWrapper):
 
     def __init__(self, dataset: Dataset):
         self.dataset = dataset
+        _disable_wrapped_transform(self)
 
     @classmethod
     def load_metadata(cls, metadata: Path) -> Any:


### PR DESCRIPTION
Certain wrappers such as `BoundingBoxMetadata` need to inject metadata before the dataset transform is applied. This PR adds support for that functionality by disabling transforms in wrapped datasets and manually applying the transform within the wrapper.