### PR TITLE
Read metadata in test factory datamodule

### DIFF
--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -96,6 +96,7 @@ class TestDicomTestFactory:
         assert 0 < len(result) <= len(dicom_files)
         assert result.index.name == "SOPInstanceUID"
         assert set(result.columns.tolist()) == {"x1", "y1", "x2", "y2", "trait", "types"}
+        assert isinstance(result.iloc[0].x1, float)
 
     @pytest.mark.parametrize("setup", [False, True])
     def test_call(self, mocker, factory, setup):
@@ -112,7 +113,14 @@ class TestDicomTestFactory:
                 dm.val_dataloader(),
                 dm.test_dataloader(),
             ):
-                assert isinstance(next(iter(dl)), dict)
+                batch = next(iter(dl))
+                assert isinstance(batch, dict)
+                # This will always be present
+                assert "img" in batch
+                # These are set by the args to __call__()
+                assert "manifest" in batch
+                assert "annotation" in batch
+                assert "bounding_boxes" in batch
 
         else:
             spy.assert_not_called()

--- a/torch_dicom/testing.py
+++ b/torch_dicom/testing.py
@@ -1,6 +1,20 @@
 from dataclasses import dataclass
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, ClassVar, Iterator, List, Sequence, Tuple, Type, cast
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    ClassVar,
+    Dict,
+    Final,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+    Type,
+    cast,
+)
 
 import numpy as np
 import pandas as pd
@@ -15,6 +29,13 @@ from torch_dicom.preprocessing import PreprocessingPipeline
 from torch_dicom.preprocessing.datamodule import PreprocessedPNGDataModule
 
 from .preprocessing import require_datamodule
+
+
+# Default filenames for test factory
+DEFAULT_MANIFEST_FILENAME: Final = "manifest.csv"
+DEFAULT_ANNOTATION_MANIFEST_FILENAME: Final = "annotation_manifest.csv"
+DEFAULT_TRACE_MANIFEST_FILENAME: Final = "trace_manifest.csv"
+DEFAULT_TRACE_EXTRA_KEYS: Final = ["trait", "types"]
 
 
 if TYPE_CHECKING:
@@ -240,10 +261,10 @@ class DicomTestFactory:
         df = pd.DataFrame(
             {
                 "SOPInstanceUID": sop_uids,
-                "x1": [box.flatten()[0] if box is not None else None for box in trace_coords],
-                "y1": [box.flatten()[1] if box is not None else None for box in trace_coords],
-                "x2": [box.flatten()[2] if box is not None else None for box in trace_coords],
-                "y2": [box.flatten()[3] if box is not None else None for box in trace_coords],
+                "x1": [int(box.flatten()[0].item()) if box is not None else None for box in trace_coords],
+                "y1": [int(box.flatten()[1].item()) if box is not None else None for box in trace_coords],
+                "x2": [int(box.flatten()[2].item()) if box is not None else None for box in trace_coords],
+                "y2": [int(box.flatten()[3].item()) if box is not None else None for box in trace_coords],
                 "trait": trace_traits,
                 "types": trace_types,
             }
@@ -255,12 +276,25 @@ class DicomTestFactory:
 
         return df
 
-    def __call__(self, setup: bool = True, **kwargs) -> PreprocessedPNGDataModule:
+    def __call__(
+        self,
+        setup: bool = True,
+        metadata_filenames: Dict[str, str] = {
+            "manifest": DEFAULT_MANIFEST_FILENAME,
+            "annotation": DEFAULT_ANNOTATION_MANIFEST_FILENAME,
+        },
+        boxes_filename: Optional[str] = DEFAULT_TRACE_MANIFEST_FILENAME,
+        boxes_extra_keys: Iterable[str] = DEFAULT_TRACE_EXTRA_KEYS,
+        **kwargs,
+    ) -> PreprocessedPNGDataModule:
         r"""Creates a :class:`PreprocessedPNGDataModule` using the factory.
 
         Args:
             setup: Whether to setup the created :class:`PreprocessedPNGDataModule` instance.
                 If ``True``, the :func:`setup` hook will be called for the ``fit`` and ``test`` stages.
+            metadata_filenames: Filenames for the manifest and annotation manifest CSV files.
+            boxes_filename: Filename for the trace manifest CSV file.
+            boxes_extra_keys: Extra keys to include in the trace manifest CSV file.
 
         Keyword Args:
             Forwarded to the :class:`PreprocessedPNGDataModule` constructor.
@@ -285,15 +319,18 @@ class DicomTestFactory:
         manifest = self.create_manifest(dicom_files)
         annotation_manifest = self.create_annotation_manifest(dicom_files)
         trace_manifest = self.create_trace_manifest(dicom_files)
-        manifest.to_csv(preprocessed_root / "manifest.csv")
-        annotation_manifest.to_csv(preprocessed_root / "annotation_manifest.csv")
-        trace_manifest.to_csv(preprocessed_root / "trace_manifest.csv")
+        manifest.to_csv(preprocessed_root / DEFAULT_MANIFEST_FILENAME)
+        annotation_manifest.to_csv(preprocessed_root / DEFAULT_ANNOTATION_MANIFEST_FILENAME)
+        trace_manifest.to_csv(preprocessed_root / DEFAULT_TRACE_MANIFEST_FILENAME)
 
         # Create the data module
         dm = PreprocessedPNGDataModule(
             train_inputs=preprocessed_root,
             val_inputs=preprocessed_root,
             test_inputs=preprocessed_root,
+            metadata_filenames=metadata_filenames,
+            boxes_filename=boxes_filename,
+            boxes_extra_keys=boxes_extra_keys,
             **kwargs,
         )
 

--- a/torch_dicom/testing.py
+++ b/torch_dicom/testing.py
@@ -258,13 +258,14 @@ class DicomTestFactory:
         trace_coords = [create_random_box(i, self.dicom_size) if has_trace[i] else None for i in range(len(sop_uids))]
 
         # Create the manifest
+        coord_dict = {
+            f"{coord}": [int(box.flatten()[i].item()) if box is not None else None for box in trace_coords]
+            for i, coord in enumerate(["x1", "y1", "x2", "y2"])
+        }
         df = pd.DataFrame(
             {
                 "SOPInstanceUID": sop_uids,
-                "x1": [int(box.flatten()[0].item()) if box is not None else None for box in trace_coords],
-                "y1": [int(box.flatten()[1].item()) if box is not None else None for box in trace_coords],
-                "x2": [int(box.flatten()[2].item()) if box is not None else None for box in trace_coords],
-                "y2": [int(box.flatten()[3].item()) if box is not None else None for box in trace_coords],
+                **coord_dict,
                 "trait": trace_traits,
                 "types": trace_types,
             }


### PR DESCRIPTION
Sets reasonable defaults so that a downstream user doesn't manually have to specify options to configure metadata CSV files in the test datamodule.