### PR TITLE
Fix random sampling for multiple datasets

### DIFF
--- a/tests/test_preprocessing/test_datamodule.py
+++ b/tests/test_preprocessing/test_datamodule.py
@@ -176,6 +176,13 @@ class TestPreprocessedPNGDataModule:
         assert isinstance(loader, DataLoader)
         assert len(next(iter(loader))["img"]) == batch_size
 
+        # Check shuffling and train sampler
+        if fn == "train_dataloader":
+            b1 = next(iter(loader))
+            b2 = next(iter(loader))
+            assert b1["path"] != b2["path"]
+            assert isinstance(module.train_sampler, RandomSampler)
+
     def test_weighted_csv_sampler(self, preprocessed_data, manifest_csv, annotation_csv, roi_csv):
         boxes_filename = roi_csv.name
         metadata_filenames = {


### PR DESCRIPTION
When standard random sampling is used, replace the training sampler with a single `RandomSampler` over all datasets rather than using `ConcatSampler`. Without this change sampling would be random within a dataset but consecutive across datasets.