### PR TITLE
Support TIFF images

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 .PHONY: clean clean-env check quality style tag-version test env upload upload-test
 
 PROJECT=torch_dicom
-QUALITY_DIRS=$(PROJECT) tests
-CLEAN_DIRS=$(PROJECT) tests
+QUALITY_DIRS=$(PROJECT) tests scripts
+CLEAN_DIRS=$(PROJECT) tests scripts
 PYTHON=pdm run python
 
 check: ## run quality checks and unit tests
@@ -81,7 +81,7 @@ test-ci: ## runs CI-only tests
 		./tests/
 
 types: node_modules
-	pdm run npx --no-install pyright tests $(PROJECT)
+	pdm run npx --no-install pyright tests $(PROJECT) scripts
 
 help: ## display this help message
 	@echo "Please use \`make <target>' where <target> is one of"

--- a/scripts/benchmark_image.py
+++ b/scripts/benchmark_image.py
@@ -1,0 +1,78 @@
+import argparse
+import tempfile
+import timeit
+from pathlib import Path
+from typing import Tuple
+
+import numpy as np
+from PIL import Image
+
+
+def generate_uint16_array(size: Tuple[int, int], random: bool = True) -> np.ndarray:
+    """Generate a uint16 array with a single channel, either random or all zeros."""
+    if random:
+        return np.random.randint(0, 65536, size=(1, *size), dtype=np.uint16)
+    return np.zeros((1, *size), dtype=np.uint16)
+
+
+def save_image(arr: np.ndarray, path: Path) -> None:
+    """Save a uint16 array as an image."""
+    Image.fromarray(arr.squeeze(), mode="I;16").save(path)
+
+
+def load_image(path: Path) -> np.ndarray:
+    """Load an image as a uint16 array."""
+    return np.array(Image.open(path)).astype(np.uint16)[np.newaxis, ...]
+
+
+def benchmark_format(
+    arr: np.ndarray, tmp_path: Path, extension: str, repetitions: int = 10
+) -> Tuple[float, float, float]:
+    """Benchmark saving and loading for a specific format."""
+    file_path = tmp_path / f"test.{extension}"
+
+    def save_operation():
+        save_image(arr, file_path)
+
+    def load_operation():
+        return load_image(file_path)
+
+    save_time = timeit.timeit(save_operation, number=repetitions) * 1000 / repetitions
+    load_time = timeit.timeit(load_operation, number=repetitions) * 1000 / repetitions
+
+    loaded_arr = load_operation()
+    assert np.array_equal(arr, loaded_arr), f"Loaded array does not match original for {extension}"
+
+    file_size_mb = file_path.stat().st_size / (1024 * 1024)
+
+    return save_time, load_time, file_size_mb
+
+
+def main(image_size: Tuple[int, int], random: bool = False) -> None:
+    """Main function to run benchmarks."""
+    arr = generate_uint16_array(image_size, random=random)
+
+    formats = {
+        "png": "PNG",
+        "tiff": "TIFF",
+    }
+
+    theoretical_size_mb = (image_size[0] * image_size[1] * 2) / (1024 * 1024)
+    print(f"Benchmarking image I/O operations for size: {image_size[0]}x{image_size[1]}")
+    print(f"Theoretical size (2 bytes per pixel): {theoretical_size_mb:.2f}MB")
+    print(f"Random data: {random}")
+    print("-" * 60)
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        tmp_path = Path(tmp_dir)
+        for ext, format_name in formats.items():
+            save_time, load_time, file_size_mb = benchmark_format(arr, tmp_path, ext)
+            print(f"{format_name} - Save: {save_time:.2f}ms, Load: {load_time:.2f}ms, Size: {file_size_mb:.2f}MB")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Benchmark image I/O operations.")
+    parser.add_argument("-s", "--image-size", nargs=2, type=int, default=(2048, 1536), help="Image size (width height)")
+    parser.add_argument("-r", "--random", action="store_true", help="Generate random image data")
+    args = parser.parse_args()
+
+    main(tuple(args.image_size))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -106,12 +106,12 @@ def image_input(images):
     return iter(images)
 
 
-@pytest.fixture
-def image_files(tmpdir_factory, images):
+@pytest.fixture(params=["png", "tiff"])
+def image_files(tmpdir_factory, images, request):
     tmp_path = tmpdir_factory.mktemp("img_data")
     paths = []
     for i, img in enumerate(images):
-        path = Path(tmp_path, f"image_{i}.png")
-        img.save(path)
+        path = Path(tmp_path, f"image_{i}.{request.param}")
+        img.save(path, format=request.param.upper())
         paths.append(path)
     return iter(paths)

--- a/tests/test_datasets/test_image.py
+++ b/tests/test_datasets/test_image.py
@@ -14,18 +14,23 @@ from torch_dicom.datasets.image import ImageInput, ImagePathDataset, ImagePathIn
 
 
 @pytest.mark.parametrize(
-    "inp,dtype",
+    "inp,dtype,format",
     [
-        (torch.rand(32, 32), np.uint8),
-        (torch.rand(3, 32, 32), np.uint8),
-        (torch.rand(32, 32), np.uint16),
-        (torch.rand(1, 32, 32), np.uint16),
-        (torch.randint(0, 256, (32, 32), dtype=torch.uint8), np.uint8),
+        (torch.rand(32, 32), np.uint8, "png"),
+        (torch.rand(3, 32, 32), np.uint8, "png"),
+        (torch.rand(32, 32), np.uint16, "png"),
+        (torch.rand(1, 32, 32), np.uint16, "png"),
+        (torch.randint(0, 256, (32, 32), dtype=torch.uint8), np.uint8, "png"),
+        (torch.rand(32, 32), np.uint8, "tiff"),
+        (torch.rand(3, 32, 32), np.uint8, "tiff"),
+        (torch.rand(32, 32), np.uint16, "tiff"),
+        (torch.rand(1, 32, 32), np.uint16, "tiff"),
+        (torch.randint(0, 256, (32, 32), dtype=torch.uint8), np.uint8, "tiff"),
     ],
 )
-def test_save_image(mocker, tmp_path, inp, dtype):
+def test_save_image(mocker, tmp_path, inp, dtype, format):
     spy = mocker.spy(Image, "fromarray")
-    path = tmp_path / "test.png"
+    path = tmp_path / f"test.{format}"
     save_image(inp, path, dtype)
     assert path.is_file()
 
@@ -39,23 +44,29 @@ def test_save_image(mocker, tmp_path, inp, dtype):
 
 @pytest.mark.parametrize("pil", [False, True])
 @pytest.mark.parametrize(
-    "inp,dtype",
+    "inp,dtype,format",
     [
-        (torch.rand(32, 32), np.uint8),
-        (torch.rand(3, 32, 32), np.uint8),
-        (torch.rand(32, 32), np.uint16),
-        (torch.rand(1, 32, 32), np.uint16),
-        (torch.randint(0, 256, (32, 32), dtype=torch.uint8), np.uint8),
+        (torch.rand(32, 32), np.uint8, "png"),
+        (torch.rand(3, 32, 32), np.uint8, "png"),
+        (torch.rand(32, 32), np.uint16, "png"),
+        (torch.rand(1, 32, 32), np.uint16, "png"),
+        (torch.randint(0, 256, (32, 32), dtype=torch.uint8), np.uint8, "png"),
+        (torch.rand(32, 32), np.uint8, "tiff"),
+        (torch.rand(3, 32, 32), np.uint8, "tiff"),
+        (torch.rand(32, 32), np.uint16, "tiff"),
+        (torch.rand(1, 32, 32), np.uint16, "tiff"),
+        (torch.randint(0, 256, (32, 32), dtype=torch.uint8), np.uint8, "tiff"),
     ],
 )
-def test_load_image(mocker, tmp_path, inp, dtype, pil):
-    mocker.spy(Image, "fromarray")
-    path = tmp_path / "test.png"
+def test_load_image(mocker, tmp_path, inp, dtype, format, pil):
+    spy = mocker.spy(Image, "fromarray")
+    path = tmp_path / f"test.{format}"
     save_image(inp, path, dtype)
 
     inp = Image.open(path) if pil else path
     result = load_image(inp)
     assert isinstance(result, TVImage)
+    spy.assert_called_once()
 
 
 class TestImageInput:
@@ -150,9 +161,10 @@ class TestImagePathDataset(TestImagePathInput):
 
 
 @pytest.mark.parametrize("dtype", [np.uint8, np.uint16])
-def test_save_and_load_image(tmp_path, dtype, dicom_size):
+@pytest.mark.parametrize("format", ["png", "tiff"])
+def test_save_and_load_image(tmp_path, dtype, format, dicom_size):
     img_tensor = torch.rand(1, *dicom_size)
-    img_path = tmp_path / "test.png"
+    img_path = tmp_path / f"test.{format}"
     save_image(img_tensor, img_path, dtype)
     assert img_path.is_file()
 

--- a/tests/test_preprocessing/test_pipeline.py
+++ b/tests/test_preprocessing/test_pipeline.py
@@ -50,10 +50,11 @@ class TestPreprocessingPipeline:
             else:
                 raise AssertionError("No matching SOPInstanceUID found")
 
-    def test_preprocess_png(self, tmp_path, dicoms, dicom_iterator, file_iterator):
+    @pytest.mark.parametrize("output_format", [OutputFormat.PNG, OutputFormat.TIFF])
+    def test_preprocess_image(self, tmp_path, dicoms, dicom_iterator, file_iterator, output_format):
         dicoms = deepcopy(dicoms)
         pipeline = PreprocessingPipeline(
-            file_iterator, dicom_iterator, output_format=OutputFormat.PNG, volume_handler=ReduceVolume()
+            file_iterator, dicom_iterator, output_format=output_format, volume_handler=ReduceVolume()
         )
         dest = Path(tmp_path, "output")
         dest.mkdir()

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -7,7 +7,7 @@ from dicom_utils.container import DicomImageFileRecord
 from torchvision.tv_tensors import BoundingBoxes, BoundingBoxFormat
 
 from torch_dicom.datasets import ImagePathDataset
-from torch_dicom.preprocessing.datamodule import PreprocessedPNGDataModule
+from torch_dicom.preprocessing.datamodule import PreprocessedDataModule
 from torch_dicom.testing import DicomTestFactory, MammogramTestFactory, choose_modulus, create_random_box
 
 
@@ -100,14 +100,14 @@ class TestDicomTestFactory:
 
     @pytest.mark.parametrize("setup", [False, True])
     def test_call(self, mocker, factory, setup):
-        spy = mocker.spy(PreprocessedPNGDataModule, "setup")
+        spy = mocker.spy(PreprocessedDataModule, "setup")
         dm = factory(setup=setup)
-        assert isinstance(dm, PreprocessedPNGDataModule)
+        assert isinstance(dm, PreprocessedDataModule)
 
         if setup:
             assert spy.call_count == 2
             # Check that all dataloaders are valid.
-            # We dont check the example members, this should be tested in PreprocessedPNGDataModule
+            # We dont check the example members, this should be tested in PreprocessedDataModule
             for dl in (
                 dm.train_dataloader(),
                 dm.val_dataloader(),

--- a/torch_dicom/datasets/image.py
+++ b/torch_dicom/datasets/image.py
@@ -24,7 +24,8 @@ class ImageExample(TypedDict):
 
 def save_image(img: Tensor, path: Path, dtype: np.dtype = cast(np.dtype, np.uint16)) -> None:
     """
-    Saves an image tensor to a PNG. Floating point inputs are expected to be in the range [0, 1].
+    Saves an image tensor to a file using PIL. Supports PNG and TIFF formats.
+    Floating point inputs are expected to be in the range [0, 1].
     Floating point inputs will be converted to ``dtype`` before saving.
 
     Args:
@@ -54,12 +55,14 @@ def save_image(img: Tensor, path: Path, dtype: np.dtype = cast(np.dtype, np.uint
     if dtype == np.uint16 and img.ndim == 3:
         raise ValueError("Saving 3-channel uint16 images is not supported")  # pragma: no cover
 
-    PILImage.fromarray(img_np).save(str(path))
+    pil_mode = "I;16" if dtype == np.uint16 else None
+    pil_img = PILImage.fromarray(img_np, mode=pil_mode)
+    pil_img.save(str(path))
 
 
 def load_image(inp: Union[PILImage.Image, Path]) -> TVImage:
     """
-    Loads an image file. The loaded image will be min max normalized
+    Loads an image file using PIL. The loaded image will be min max normalized
     based on the dtype of the image.
 
     Args:

--- a/torch_dicom/preprocessing/__init__.py
+++ b/torch_dicom/preprocessing/__init__.py
@@ -7,7 +7,7 @@ from .resize import Resize
 
 def datamodule_available() -> bool:
     try:
-        from .datamodule import PreprocessedPNGDataModule  # noqa: F401
+        from .datamodule import PreprocessedDataModule  # noqa: F401
     except ImportError:
         return False
     return True
@@ -16,7 +16,7 @@ def datamodule_available() -> bool:
 def require_datamodule() -> None:
     if not datamodule_available():
         raise ImportError(
-            "PreprocessedPNGDataModule is not available." "Please install the `torch-dicom[datamodule]` extra."
+            "PreprocessedDataModule is not available." "Please install the `torch-dicom[datamodule]` extra."
         )
 
 

--- a/torch_dicom/preprocessing/datamodule.py
+++ b/torch_dicom/preprocessing/datamodule.py
@@ -1,7 +1,7 @@
 from copy import copy
 from functools import partial
 from pathlib import Path
-from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Set, Sized, Union, cast
+from typing import Any, Callable, Dict, Final, Iterable, List, Optional, Sequence, Set, Sized, Union, cast
 
 from deep_helpers.data.sampler import ConcatSampler
 from deep_helpers.structs import Mode
@@ -30,6 +30,8 @@ from torch_dicom.datasets.helpers import Transform
 
 # NOTE: jsonargparse has trouble if os.PathLike is in the union
 PathLike = Union[str, Path]
+
+IMAGE_SUFFIXES: Final = (".png", ".tiff")
 
 
 def _prepare_inputs(inputs: Union[PathLike, Sequence[PathLike]]) -> List[Path]:
@@ -175,7 +177,8 @@ class PreprocessedPNGDataModule(LightningDataModule):
 
         # Create a dataset of preprocessed images and apply the preprocessing metadata wrapper
         # NOTE: Preprocessed files are named as SOPInstanceUID.png
-        images = filter(lambda p: p.stem not in sopuid_exclusions, target.rglob("*.png"))
+        images = filter(lambda p: p.suffix in IMAGE_SUFFIXES, target.rglob("*"))
+        images = filter(lambda p: p.stem not in sopuid_exclusions, images)
         dataset = ImagePathDataset(images, **kwargs)
         dataset = PreprocessingConfigMetadata(dataset)
 

--- a/torch_dicom/preprocessing/datamodule.py
+++ b/torch_dicom/preprocessing/datamodule.py
@@ -61,7 +61,7 @@ def _prepare_sopuid_exclusions(sopuid_exclusions: PathLike | Iterable[str] | Non
         return set()
 
 
-class PreprocessedPNGDataModule(LightningDataModule):
+class PreprocessedDataModule(LightningDataModule):
     r"""Data module for preprocessed PNG images.
 
     .. note::

--- a/torch_dicom/preprocessing/pipeline.py
+++ b/torch_dicom/preprocessing/pipeline.py
@@ -28,6 +28,7 @@ from ..datasets.image import save_image
 class OutputFormat(StrEnum):
     PNG = "png"
     DICOM = "dcm"
+    TIFF = "tiff"
 
 
 def update_dicom(dicom: Dicom, img: Tensor) -> Dicom:
@@ -202,7 +203,7 @@ class PreprocessingPipeline:
         dest_path.parent.mkdir(exist_ok=True, parents=True)
         if output_format == OutputFormat.DICOM:
             dicom.save_as(dest_path, write_like_original=False)
-        elif output_format == OutputFormat.PNG:
+        elif output_format in (OutputFormat.PNG, OutputFormat.TIFF):
             img = result["img"]
             img.squeeze_(0)
             dtype = cast(np.dtype, np.uint16 if dicom.BitsAllocated == 16 else np.uint8)

--- a/torch_dicom/testing.py
+++ b/torch_dicom/testing.py
@@ -27,7 +27,7 @@ from dicom_utils.volume import ReduceVolume
 from torchvision.tv_tensors import BoundingBoxes, BoundingBoxFormat
 
 from torch_dicom.preprocessing import PreprocessingPipeline
-from torch_dicom.preprocessing.datamodule import PreprocessedPNGDataModule
+from torch_dicom.preprocessing.datamodule import PreprocessedDataModule
 
 from .preprocessing import require_datamodule
 
@@ -40,15 +40,15 @@ DEFAULT_TRACE_EXTRA_KEYS: Final = ["trait", "types"]
 
 
 if TYPE_CHECKING:
-    from torch_dicom.preprocessing.datamodule import PreprocessedPNGDataModule
+    from torch_dicom.preprocessing.datamodule import PreprocessedDataModule
 else:
     try:
-        from torch_dicom.preprocessing.datamodule import PreprocessedPNGDataModule
+        from torch_dicom.preprocessing.datamodule import PreprocessedDataModule
     except ImportError:
-        PreprocessedPNGDataModule = None
+        PreprocessedDataModule = None
 
 
-M = TypeVar("M", bound=PreprocessedPNGDataModule)
+M = TypeVar("M", bound=PreprocessedDataModule)
 
 
 def choose_modulus(val: int, choices: Sequence[Any]) -> Any:
@@ -291,26 +291,26 @@ class DicomTestFactory:
         },
         boxes_filename: Optional[str] = DEFAULT_TRACE_MANIFEST_FILENAME,
         boxes_extra_keys: Iterable[str] = DEFAULT_TRACE_EXTRA_KEYS,
-        datamodule_class: Type[M] = PreprocessedPNGDataModule,
+        datamodule_class: Type[M] = PreprocessedDataModule,
         **kwargs,
     ) -> M:
-        r"""Creates a :class:`PreprocessedPNGDataModule` using the factory.
+        r"""Creates a :class:`PreprocessedDataModule` using the factory.
 
         Args:
-            setup: Whether to setup the created :class:`PreprocessedPNGDataModule` instance.
+            setup: Whether to setup the created :class:`PreprocessedDataModule` instance.
                 If ``True``, the :func:`setup` hook will be called for the ``fit`` and ``test`` stages.
             metadata_filenames: Filenames for the manifest and annotation manifest CSV files.
             boxes_filename: Filename for the trace manifest CSV file.
             boxes_extra_keys: Extra keys to include in the trace manifest CSV file.
-            datamodule_class: The specific :class:`PreprocessedPNGDataModule` class to use.
+            datamodule_class: The specific :class:`PreprocessedDataModule` class to use.
 
         Keyword Args:
-            Forwarded to the :class:`PreprocessedPNGDataModule` constructor.
+            Forwarded to the :class:`PreprocessedDataModule` constructor.
 
         Returns:
-            A :class:`PreprocessedPNGDataModule` instance.
+            A :class:`PreprocessedDataModule` instance.
         """
-        # PreprocessedPNGDataModule is an optional dependency. Validate that it is installed.
+        # PreprocessedDataModule is an optional dependency. Validate that it is installed.
         require_datamodule()
 
         # Create the DICOM files


### PR DESCRIPTION
The following benchmarks were run to compare the performance of TIFF and PNG on 16 bit grayscale images.

Noisy data, no TIFF compression
```
Benchmarking image I/O operations for size: 2048x1536
Theoretical size (2 bytes per pixel): 6.00MB
Random data: True
------------------------------------------------------------
PNG - Save: 321.24ms, Load: 49.73ms, Size: 6.01MB
TIFF - Save: 13.63ms, Load: 9.37ms, Size: 6.00MB
```

Noisy data, TIFF compression (`tiff_adobe_deflate`)
```
Benchmarking image I/O operations for size: 2048x1536
Theoretical size (2 bytes per pixel): 6.00MB
Random data: True
------------------------------------------------------------
PNG - Save: 323.64ms, Load: 49.32ms, Size: 6.01MB
TIFF - Save: 156.10ms, Load: 16.87ms, Size: 6.00MB
```

All-zeros, no TIFF compression
```
Benchmarking image I/O operations for size: 2048x1536
Theoretical size (2 bytes per pixel): 6.00MB
Random data: False
------------------------------------------------------------
PNG - Save: 34.07ms, Load: 27.67ms, Size: 0.01MB
TIFF - Save: 12.46ms, Load: 9.45ms, Size: 6.00MB
```

All-zeros, TIFF compression (`tiff_adobe_deflate`)
```
Benchmarking image I/O operations for size: 2048x1536
Theoretical size (2 bytes per pixel): 6.00MB
Random data: False
------------------------------------------------------------
PNG - Save: 34.16ms, Load: 28.02ms, Size: 0.01MB
TIFF - Save: 23.00ms, Load: 29.23ms, Size: 0.01MB
```

These results indicate that TIFF is comparable to or far faster than PNG depending on the configuration. TIFF is also well suited for medical data with features like multi-frame support. As such, this PR adds support for TIFF in both dataset classes as well as in the preprocessing pipeline. TIFF should be favored over PNG, especially in situations where CPU decode time is a bottleneck.